### PR TITLE
fix: wrong output of CH1903Y coordinates for all cabin huts

### DIFF
--- a/src/Controller/ContentElement/SacCabinsDetailController.php
+++ b/src/Controller/ContentElement/SacCabinsDetailController.php
@@ -102,8 +102,7 @@ class SacCabinsDetailController extends AbstractContentElementController
 
                 if (\is_array($arrCoord) && 2 === \count($arrCoord)) {
                     $row['hasCoords'] = true;
-                    $arrCoord =
-                        $row['coordsCH1903X'] = trim($arrCoord[0]);
+                    $row['coordsCH1903X'] = trim($arrCoord[0]);
                     $row['coordsCH1903Y'] = trim($arrCoord[1]);
                 }
             }


### PR DESCRIPTION
Current coordinate problem for CH1903Y / N:
...E=678120.00&N=7.00...

Correct coordinates according to db:
...E=678120.00&N=196490...

