### PR TITLE
Full width for cabins map view

### DIFF
--- a/src/Resources/contao/templates/ce_sac_cabins_detail.html.twig
+++ b/src/Resources/contao/templates/ce_sac_cabins_detail.html.twig
@@ -134,7 +134,7 @@
         <div class="col-xl-4">
             {% if cabin.hasCoords %}
                 <div class="embed-responsive embed-responsive-4by3">
-                    <iframe src="{{ cabin.geoLink|format(cabin.coordsCH1903X,cabin.coordsCH1903Y) }}"></iframe>
+                    <iframe src="{{ cabin.geoLink|format(cabin.coordsCH1903X,cabin.coordsCH1903Y) }}" width="100%" height="100%" allow="geolocation"></iframe>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
feat: use full width of outer div class for map view

Reason:
map.geo.admin.ch iframe has a default size of 300x150 px. A width with 300px is too small to display navigation buttons like "+" and "-" for zooming. So, extend the size to its outer div width.